### PR TITLE
Can add custom query filters.

### DIFF
--- a/src/Filterable.php
+++ b/src/Filterable.php
@@ -13,12 +13,14 @@ use Illuminate\Database\Eloquent\Builder;
 trait Filterable
 {
     /**
-     * @param Builder $builder
+     * @param Builder     $builder
      * @param QueryFilter $filter
+     * @param array       $queries
+     *
      * @return Builder
      */
-    public static function scopeFilter(Builder $builder, QueryFilter $filter) : Builder
+    public static function scopeFilter(Builder $builder, QueryFilter $filter, array $queries = []) : Builder
     {
-        return $filter->apply($builder);
+        return $filter->setQueries($queries)->apply($builder);
     }
 }

--- a/src/QueryFilter.php
+++ b/src/QueryFilter.php
@@ -15,17 +15,21 @@ class QueryFilter
     /**
      * @var
      */
-    protected $request;
+    private $request;
 
     /**
      * @var
      */
     protected $builder;
 
-    public function __construct(Request $request, Builder $builder)
+    /**
+     * @var array
+     */
+    protected $queries = [];
+
+    public function __construct(Request $request)
     {
         $this->setRequest($request);
-        $this->setBuilder($builder);
     }
 
     /**
@@ -36,7 +40,7 @@ class QueryFilter
     {
         $this->setBuilder($builder);
 
-        $params = $this->getRequest()->all();
+        $params = $this->getFilterParams();
         foreach ($params as $method => $param) {
             $method = sprintf('apply%sProperty', ucwords($method, '_'));
             if (method_exists($this, $method)) {
@@ -77,5 +81,32 @@ class QueryFilter
     public function getBuilder() : Builder
     {
         return $this->builder;
+    }
+
+    /**
+     * @param array $queries
+     *
+     * @return $this
+     */
+    public function setQueries (array $queries) : self
+    {
+        $this->queries = $queries;
+
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueries () : array
+    {
+        return $this->queries;
+    }
+
+    /**
+     * @return array
+     */
+    private function getFilterParams () : array {
+        return array_merge($this->getRequest()->all(), $this->getQueries());
     }
 }


### PR DESCRIPTION
- The `Builder` class is set from the `apply` method. removed from the constructor to reduce the overhead.
- If a developer wants to pass extra data for his to be filtered, he can then pass an array as the second param for the `filter` method on Models.
- Array for queries has a higher priority than the request values. If the same key exists in the request and custom queries, custom queries will take precedence over request values.